### PR TITLE
Post parsed data to IPFS via infura

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -1,6 +1,7 @@
 const express = require('express');
 const cors = require('cors');
 const multer = require('multer');
+const bodyParser = require('body-parser')
 const upload = multer();
 
 const app = express();
@@ -12,9 +13,11 @@ app.get('/api/helloworld', (req, res) => {
   res.send({ express: 'Hello dPanc!' });
 });
 
-app.listen(port, () => console.log(`Listening on port ${port}`));
-
 // Enable Cross-Origin Resource Sharing
 app.use(cors());
+// Enable body in post requests
+app.use(bodyParser.json({limit: '10mb', extended: true}))
+
+app.listen(port, () => console.log(`Listening on port ${port}`));
 
 app.post('/upload', upload.any(), data_controller.parseCSV);

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "homepage": "https://github.com/Blockternship/dPanc#readme",
   "dependencies": {
     "axios": "^0.18.0",
+    "body-parser": "^1.18.3",
     "cors": "^2.8.4",
     "express": "^4.16.3",
     "multer": "^1.3.1",

--- a/src/components/Form.js
+++ b/src/components/Form.js
@@ -1,31 +1,70 @@
-import React from 'react';
+import React, { Component } from 'react';
 import { Card, Form } from 'semantic-ui-react';
-import { post } from 'axios';
+import axios from 'axios';
 
-class FormsPage extends React.Component {
+class FormsPage extends Component {
   state = {
-    value: '',
     file: '',
   };
 
-  // Submit form details and file to express server to process
-  // If processing successful, then prompt user's MetaMask to send data to IPFS
+  /**
+  * Submit form details and file to express server to parse.
+  *
+  * If processing successful, then upload the parsed data to IPFS.
+  */
   onFormSubmit = async (event) => {
     event.preventDefault();
 
     const response = await this.uploadFile(this.state.file);
 
-    console.log(response);
+    // Upload parsed data to IPFS
+    this.uploadToIpfs(response.data);
   };
 
-  // Function to change file when user uploads a new file
+  /**
+  * Upload parsed data to IPFS via infura.
+  */
+  uploadToIpfs = async (parsedData) => {
+    var formData = new FormData();
+    formData.append("file", JSON.stringify(parsedData));
+
+    const url = 'https://ipfs.infura.io:5001/api/v0/add';
+    const config = {
+        headers: {
+            'Content-Type': 'multipart/form-data',
+        }
+    }
+
+    try {
+      const response = await axios.post(url, formData, config);
+      const ipfsHash = response.data.Hash;
+
+      this.uploadIPFSHash(ipfsHash);
+    } catch (e) {
+      console.log(e);
+    }
+  };
+
+  /**
+  * Upload IPFS hash of parsed data to dPanc contract on Ethereum network.
+  */
+  uploadIPFSHash = async (ipfsHash) => {
+    console.log(`Uploading ${ipfsHash} to dPanc contract...`);
+    // TODO: Finish and deploy contract, and upload IPFS hash to contract here
+  };
+
+  /**
+  * Function to save file state when user uploads a new file.
+  */
   onChange = (event) => {
     this.setState({
       file: event.target.files[0],
     })
   };
 
-  // Make post call with FormData to express server
+  /**
+  * Post FormData to express server
+  */
   uploadFile = (file) => {
     const url = 'http://localhost:3001/upload/';
     const formData = new FormData();
@@ -36,7 +75,7 @@ class FormsPage extends React.Component {
             'Access-Control-Allow-Origin': '*',
         }
     }
-    return post(url, formData, config)
+    return axios.post(url, formData, config)
   };
 
   render() {
@@ -61,7 +100,7 @@ class FormsPage extends React.Component {
         </Card.Content>
       </Card>
     );
-  }
+  };
 };
 
 export default FormsPage;

--- a/yarn.lock
+++ b/yarn.lock
@@ -1093,6 +1093,24 @@ body-parser@1.18.2, body-parser@^1.16.0:
     raw-body "2.3.2"
     type-is "~1.6.15"
 
+<<<<<<< HEAD
+=======
+body-parser@^1.16.0, body-parser@^1.18.3:
+  version "1.18.3"
+  resolved "https://registry.yarnpkg.com/body-parser/-/body-parser-1.18.3.tgz#5b292198ffdd553b3a0f20ded0592b956955c8b4"
+  dependencies:
+    bytes "3.0.0"
+    content-type "~1.0.4"
+    debug "2.6.9"
+    depd "~1.1.2"
+    http-errors "~1.6.3"
+    iconv-lite "0.4.23"
+    on-finished "~2.3.0"
+    qs "6.5.2"
+    raw-body "2.3.3"
+    type-is "~1.6.16"
+
+>>>>>>> Post parsed data to IPFS via infura
 bonjour@^3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/bonjour/-/bonjour-3.5.0.tgz#8e890a183d8ee9a2393b3844c691a42bcf7bc9f5"


### PR DESCRIPTION
Resolves #26 

After parsing the data in express server, react component `Form` will make a POST to infura to save the parsed data to IPFS. 

We currently just log the returned IPFS hash, as we need to finish and deploy the `dPanc` contract before we can upload the IPFS hash for a user...